### PR TITLE
feat: add API_TOKEN_PEPPERS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Containers are configured using parameters passed at runtime (such as those abov
 | `-e REDIS_DB_CACHE=` | Redis database ID for caching (default: 1) |
 | `-e BASE_PATH=` | The path you will use to access the app (i.e., /netbox, default: none) |
 | `-e CSRF_TRUSTED_ORIGINS=` | List of comma-separated, single quoted, trusted origins. Must include protocol, and port if applicable (default: []) |
+| `-e API_TOKEN_PEPPERS=` | Mapping of token pepper IDs to pepper strings for API token hashing (default: {}) |
 | `-e REMOTE_AUTH_ENABLED=` | Enable remote authentication (default: False) |
 | `-e REMOTE_AUTH_BACKEND=` | Python path to the custom Django authentication backend to use for external user authentication (default: netbox.authentication.RemoteUserBackend) |
 | `-e REMOTE_AUTH_HEADER=` | Name of the HTTP header which informs NetBox of the currently authenticated user. (default: HTTP_REMOTE_USER) |

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -37,6 +37,7 @@ opt_param_usage_include_env: true
 opt_param_env_vars:
   - {env_var: "BASE_PATH", env_value: "", desc: "The path you will use to access the app (i.e., /netbox, default: none)"}
   - {env_var: "CSRF_TRUSTED_ORIGINS", env_value: "", desc: "List of comma-separated, single quoted, trusted origins. Must include protocol, and port if applicable (default: [])"}
+  - {env_var: "API_TOKEN_PEPPERS", env_value: "", desc: "Mapping of token pepper IDs to pepper strings for API token hashing (default: {})"}
   - {env_var: "REMOTE_AUTH_ENABLED", env_value: "", desc: "Enable remote authentication (default: False)"}
   - {env_var: "REMOTE_AUTH_BACKEND", env_value: "", desc: "Python path to the custom Django authentication backend to use for external user authentication (default: netbox.authentication.RemoteUserBackend)"}
   - {env_var: "REMOTE_AUTH_HEADER", env_value: "", desc: "Name of the HTTP header which informs NetBox of the currently authenticated user. (default: HTTP_REMOTE_USER)"}
@@ -96,6 +97,7 @@ init_diagram: |
   "netbox:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "16.06.26:", desc: "Add API_TOKEN_PEPPERS env settings."}
   - {date: "05.01.26:", desc: "Rebase to Alpine 3.23. Add CSRF_TRUSTED_ORIGINS env settings. Drop support for environments with explicitly disabled IPv6."}
   - {date: "26.08.24:", desc: "Restructure init to allow for plugins as mods."}
   - {date: "16.07.24:", desc: "Add required packages for LDAP support."}

--- a/root/defaults/configuration.py
+++ b/root/defaults/configuration.py
@@ -63,6 +63,9 @@ REDIS = {
 # https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-SECRET_KEY
 SECRET_KEY = '{{SECRET_KEY}}'
 
+# List of API token peppers used to hash v2 API tokens. Keep this set in sync across all NetBox instances using the same
+# token data.
+API_TOKEN_PEPPERS = {{API_TOKEN_PEPPERS}}
 
 #########################
 #                       #

--- a/root/etc/s6-overlay/s6-rc.d/init-netbox-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-netbox-config/run
@@ -5,40 +5,55 @@ mkdir -p \
     /app/netbox/netbox/static \
     /config/scripts
 
-declare -A NETBOX_CONF
-NETBOX_CONF[ALLOWED_HOST]=${ALLOWED_HOST:-netbox.example.com}
-NETBOX_CONF[BASE_PATH]=${BASE_PATH:-}
-NETBOX_CONF[CSRF_TRUSTED_ORIGINS]=${CSRF_TRUSTED_ORIGINS:-}
-NETBOX_CONF[DB_NAME]=${DB_NAME:-netbox}
-NETBOX_CONF[DB_USER]=${DB_USER:-root}
-NETBOX_CONF[DB_PASSWORD]=${DB_PASSWORD:-}
-NETBOX_CONF[DB_HOST]=${DB_HOST:-postgres}
-NETBOX_CONF[DB_PORT]=${DB_PORT:-}
-NETBOX_CONF[REDIS_HOST]=${REDIS_HOST:-redis}
-NETBOX_CONF[REDIS_PORT]=${REDIS_PORT:-6379}
-NETBOX_CONF[REDIS_USERNAME]=${REDIS_USERNAME:-}
-NETBOX_CONF[REDIS_PASSWORD]=${REDIS_PASSWORD:-}
-NETBOX_CONF[REDIS_DB_TASK]=${REDIS_DB_TASK:-0}
-NETBOX_CONF[REDIS_DB_CACHE]=${REDIS_DB_CACHE:-1}
-NETBOX_CONF[REMOTE_AUTH_ENABLED]=${REMOTE_AUTH_ENABLED:-False}
-NETBOX_CONF[REMOTE_AUTH_BACKEND]=${REMOTE_AUTH_BACKEND:-netbox.authentication.RemoteUserBackend}
-NETBOX_CONF[REMOTE_AUTH_HEADER]=${REMOTE_AUTH_HEADER:-HTTP_REMOTE_USER}
-NETBOX_CONF[REMOTE_AUTH_AUTO_CREATE_USER]=${REMOTE_AUTH_AUTO_CREATE_USER:-False}
-NETBOX_CONF[REMOTE_AUTH_DEFAULT_GROUPS]=${REMOTE_AUTH_DEFAULT_GROUPS:-[]}
-NETBOX_CONF[REMOTE_AUTH_DEFAULT_PERMISSIONS]=${REMOTE_AUTH_DEFAULT_PERMISSIONS:-{}}
+render_configuration() {
+    local config_file=$1
+    local config_text
+    local key
+    local value
 
-cd /app/netbox/netbox || exit 1
+    config_text=$(<"$config_file")
 
-NETBOX_CONF[SECRET_KEY]=${SECRET_KEY:-$(python3 ./generate_secret_key.py)}
+    if [[ -z ${SECRET_KEY:-} ]]; then
+        cd /app/netbox/netbox || exit 1
+        SECRET_KEY=$(python3 ./generate_secret_key.py)
+    fi
+
+    while IFS='=' read -r key value; do
+        value=${!key:-$value}
+        config_text=${config_text//"{{${key}}}"/"$value"}
+    done <<'EOF'
+ALLOWED_HOST=netbox.example.com
+BASE_PATH=
+CSRF_TRUSTED_ORIGINS=
+DB_NAME=netbox
+DB_USER=root
+DB_PASSWORD=
+DB_HOST=postgres
+DB_PORT=5432
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_USERNAME=
+REDIS_PASSWORD=
+REDIS_DB_TASK=0
+REDIS_DB_CACHE=1
+REMOTE_AUTH_ENABLED=False
+REMOTE_AUTH_BACKEND=netbox.authentication.RemoteUserBackend
+REMOTE_AUTH_HEADER=HTTP_REMOTE_USER
+REMOTE_AUTH_AUTO_CREATE_USER=False
+REMOTE_AUTH_DEFAULT_GROUPS=[]
+REMOTE_AUTH_DEFAULT_PERMISSIONS={}
+API_TOKEN_PEPPERS={}
+EOF
+
+    config_text=${config_text//"{{SECRET_KEY}}"/"$SECRET_KEY"}
+    printf '%s' "$config_text" > "$config_file"
+}
 
 if [[ ! -f "/config/configuration.py" ]]; then
     cp /defaults/configuration.py /config/configuration.py
-
-    # sed in values or skip if value not set
-    for KEY in "${!NETBOX_CONF[@]}"; do \
-        sed -i 's|{{'$KEY'}}|'${NETBOX_CONF[$KEY]}'|g' /config/configuration.py
-    done
 fi
+
+render_configuration /config/configuration.py
 
 if [[ ! -e "/config/media" ]] && [[ -e "/app/netbox/netbox/media" ]]; then
     mv /app/netbox/netbox/media /config/media


### PR DESCRIPTION
## Description:
Add support for `API_TOKEN_PEPPERS` in the NetBox container so v2 API tokens can be configured from the environment.

I reworked the existing `declare -A NETBOX_CONF` approach because it was being used as a staging layer rather than the actual rendering path for NetBox’s runtime configuration. For `API_TOKEN_PEPPERS`, that extra indirection made the change harder to integrate cleanly, since the value needs to end up in `configuration.py` as a valid Python literal. Keeping the substitution logic in one shell-based flow inside `init-netbox-config` preserves the image’s existing pattern, avoids duplicating configuration state, and makes the new setting fit naturally alongside the others.

## Benefits of this PR and context:
- Lets NetBox read API token peppers from the same container config used for the rest of the app.
- Keeps the init flow in shell, matching the rest of the startup script.
- Removes the need for a manual override when enabling v2 token support.

`CSRF_TRUSTED_ORIGINS` is included because it is part of the same runtime config path and is relevant for deployments behind proxies or on custom local domains, where Django’s origin checks would otherwise block requests.

## How Has This Been Tested?
Built the image in an isolated Docker Compose stack with Postgres and Redis, then verified:
- `API_TOKEN_PEPPERS` is rendered into `/config/configuration.py`
- the container starts cleanly with a 50+ character pepper value
- a NetBox v2 token can be created and authenticated against the API

Proof:
- `docker compose -f /tmp/netbox-test-compose.yml up -d --build`
- `docker compose -f /tmp/netbox-test-compose.yml exec -T netbox ...` showed `API_TOKEN_PEPPERS` rendered in `/config/configuration.py`
- `GET /api/users/tokens/` with a v2 Bearer token returned `HTTP 200`

## Source / References:
- NetBox required-parameters docs: https://netbox.readthedocs.io/en/stable/configuration/required-parameters/#api_token_peppers
- NetBox security docs: https://netbox.readthedocs.io/en/stable/configuration/security/#csrf_trusted_origins
